### PR TITLE
Fix #1 Show ToolWindow

### DIFF
--- a/src/main/java/com/github/users/wileespaghetti/rabbitmq/RabbitmqToolWindowFactory.java
+++ b/src/main/java/com/github/users/wileespaghetti/rabbitmq/RabbitmqToolWindowFactory.java
@@ -1,0 +1,13 @@
+package com.github.users.wileespaghetti.rabbitmq;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class RabbitmqToolWindowFactory implements ToolWindowFactory {
+    @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,8 @@
     -->
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Add your extensions here -->
+        <toolWindow id="RabbitMQ" anchor="bottom" icon="RabbitmqIcons.ToolWindowRabbitmq"
+                    factoryClass="com.github.users.wileespaghetti.rabbitmq.RabbitmqToolWindowFactory" />
     </extensions>
 
     <actions>


### PR DESCRIPTION
Adds the empty `RabbitMQ` toolwindow to the bottom of the IDE