### PR TITLE
Fix #10 add action to open configuration dialog

### DIFF
--- a/src/main/java/com/github/users/wileespaghetti/rabbitmq/actions/testing/OpenRabbitmqConfigurationDialog.java
+++ b/src/main/java/com/github/users/wileespaghetti/rabbitmq/actions/testing/OpenRabbitmqConfigurationDialog.java
@@ -1,12 +1,14 @@
 package com.github.users.wileespaghetti.rabbitmq.actions.testing;
 
+import com.github.users.wileespaghetti.rabbitmq.view.ui.RabbitmqConnectionManagerDialog;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class OpenRabbitmqConfigurationDialog extends AnAction {
 
     @Override
-    public void actionPerformed(AnActionEvent e) {
-        // TODO: insert action logic here
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        RabbitmqConnectionManagerDialog.showDialog();
     }
 }

--- a/src/main/java/com/github/users/wileespaghetti/rabbitmq/actions/testing/OpenRabbitmqConfigurationDialog.java
+++ b/src/main/java/com/github/users/wileespaghetti/rabbitmq/actions/testing/OpenRabbitmqConfigurationDialog.java
@@ -1,0 +1,12 @@
+package com.github.users.wileespaghetti.rabbitmq.actions.testing;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+
+public class OpenRabbitmqConfigurationDialog extends AnAction {
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+        // TODO: insert action logic here
+    }
+}

--- a/src/main/java/com/github/users/wileespaghetti/rabbitmq/view/ui/RabbitmqConnectionManagerDialog.java
+++ b/src/main/java/com/github/users/wileespaghetti/rabbitmq/view/ui/RabbitmqConnectionManagerDialog.java
@@ -1,0 +1,34 @@
+package com.github.users.wileespaghetti.rabbitmq.view.ui;
+
+import com.intellij.openapi.ui.DialogWrapper;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+// com.intellij.database.view.ui.DataSourceManagerDialog
+public class RabbitmqConnectionManagerDialog extends DialogWrapper {
+    public RabbitmqConnectionManagerDialog() {
+        super(true);
+        init();
+        setTitle("RabbitMQ");
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        JPanel dialogPanel = new JPanel(new BorderLayout());
+
+        JLabel label = new JLabel("Hello World");
+        label.setPreferredSize(new Dimension(100, 100));
+        dialogPanel.add(label, BorderLayout.CENTER);
+
+        return dialogPanel;
+    }
+
+    public static void showDialog() {
+        RabbitmqConnectionManagerDialog dialog = new RabbitmqConnectionManagerDialog();
+        dialog.show();
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,5 +20,10 @@
 
     <actions>
         <!-- Add your actions here -->
+        <action id="Rabbitmq.OpenConfiguration"
+                class="com.github.users.wileespaghetti.rabbitmq.actions.testing.OpenRabbitmqConfigurationDialog"
+                text="RabbitMQ Configuration" description="Opens the RabbitMQ Configuration Dialog">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
- [X] Menu item with is added to the Tools menu
- [X] Menu item shows the text RabbitMQ Configuration
- [X] Menu item opens the RabbitMQ configuration dialog when clicked

![issue-10-tools-menu](https://user-images.githubusercontent.com/2218608/59970595-2bf5ab00-9530-11e9-8c6f-d09fec5f6442.png)

![image](https://user-images.githubusercontent.com/2218608/59970599-34e67c80-9530-11e9-95e3-e475db741a83.png)
